### PR TITLE
Show kickstart flag warning only when set

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -346,7 +346,7 @@ func main() {
 		go osservice.SetupServiceManagement(constant.SystemServiceName, systemChecker.svcInterruptCh, appDoneCh)
 
 		// sofwareupdated is a macOS daemon that automatically updates Apple software.
-		if !c.Bool("disable-kickstart-softwareupdated") && runtime.GOOS == "darwin" {
+		if c.Bool("disable-kickstart-softwareupdated") && runtime.GOOS == "darwin" {
 			log.Warn().Msg("fleetd no longer automatically kickstarts softwareupdated. The --disable-kickstart-softwareupdated flag, which was previously used to disable this behavior, has been deprecated and will be removed in a future version")
 		}
 


### PR DESCRIPTION
The initial implementation of this warning in #12072 used the same `if !c.Bool("disable-kickstart-softwareupdated")` check as the old code, but the body of the `if` was the kickstart which was being skipped, now it is the warning. So currently the warning is showing only when the flag is *not* used.

I'm not building this software myself, just an end user who had a version of this assigned. Since I noticed the warning in logs and figured I'd submit a PR, please feel free to take it over to finish the checklist.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).